### PR TITLE
Feedback round1

### DIFF
--- a/R/msaGaugeRR.R
+++ b/R/msaGaugeRR.R
@@ -94,7 +94,7 @@ msaGaugeRR <- function(jaspResults, dataset, options, ...){
         jaspResults[["gaugeScatterOperators"]] <- createJaspContainer(gettext("Scatterplot Operators"))
         jaspResults[["gaugeScatterOperators"]]$position <- 4
       }
-      jaspResults[["gaugeScatterOperators"]] <- .gaugeScatterPlotOperators(dataset = dataset, measurements = measurements, parts = parts, operators = operators, options =  options)
+      jaspResults[["gaugeScatterOperators"]] <- .gaugeScatterPlotOperators(dataset = dataset, measurements = measurements, parts = parts, operators = operators, options =  options, ready = ready)
     }
 
     # Measurement by Part Graph
@@ -104,7 +104,7 @@ msaGaugeRR <- function(jaspResults, dataset, options, ...){
         jaspResults[["gaugeByPart"]]$position <- 5
       }
 
-      jaspResults[["gaugeByPart"]] <- .gaugeByPartGraph(dataset = dataset, measurements = measurements, parts = parts, operators = operators, options =  options)
+      jaspResults[["gaugeByPart"]] <- .gaugeByPartGraph(dataset = dataset, measurements = measurements, parts = parts, operators = operators, options =  options, ready = ready)
     }
 
     # Measurement by Operator Box Plot
@@ -113,7 +113,7 @@ msaGaugeRR <- function(jaspResults, dataset, options, ...){
         jaspResults[["gaugeByOperator"]] <- createJaspContainer(gettext("Measurement by Operator Graph"))
         jaspResults[["gaugeByOperator"]]$position <- 6
       }
-      jaspResults[["gaugeByOperator"]] <- .gaugeByOperatorGraph(dataset = dataset, measurements = measurements, parts = parts, operators = operators, options =  options)
+      jaspResults[["gaugeByOperator"]] <- .gaugeByOperatorGraph(dataset = dataset, measurements = measurements, parts = parts, operators = operators, options =  options, ready = ready)
     }
 
     # Parts by Operator Interaction Plot
@@ -122,7 +122,7 @@ msaGaugeRR <- function(jaspResults, dataset, options, ...){
         jaspResults[["gaugeByInteraction"]] <- createJaspContainer(gettext("Parts by Operator Interaction Graph"))
         jaspResults[["gaugeByInteraction"]]$position <- 7
       }
-      jaspResults[["gaugeByInteraction"]] <- .gaugeByInteractionGraph(dataset = dataset, measurements = measurements, parts = parts, operators = operators, options =  options)
+      jaspResults[["gaugeByInteraction"]] <- .gaugeByInteractionGraph(dataset = dataset, measurements = measurements, parts = parts, operators = operators, options =  options, ready = ready)
     }
 
   }
@@ -532,90 +532,81 @@ msaGaugeRR <- function(jaspResults, dataset, options, ...){
   return(plot)
 }
 
-.gaugeByPartGraph <- function(dataset, measurements, parts, operators, options){
-
-  dataset <- tidyr::gather(dataset, Repetition, Measurement, measurements[1]:measurements[length(measurements)], factor_key=TRUE)
-
-  means <- aggregate(dataset["Measurement"], dataset[parts], mean)
-
+.gaugeByPartGraph <- function(dataset, measurements, parts, operators, options, ready){
 
   plot <- createJaspPlot(title = gettext("Measurements by Part"))
 
   plot$dependOn(c("gaugeByPart", "gaugeByPartAll", "gaugeRRmethod"))
 
-  p <- ggplot2::ggplot()
+  if (ready){
+    dataset <- tidyr::gather(dataset, Repetition, Measurement, measurements[1]:measurements[length(measurements)], factor_key=TRUE)
+    means <- aggregate(dataset["Measurement"], dataset[parts], mean)
 
-  if(options$gaugeByPartAll)
-    p <- p + jaspGraphs::geom_point(data = dataset, ggplot2::aes_string(x = parts, y = "Measurement"), col = "gray")
+    p <- ggplot2::ggplot()
 
+    if(options$gaugeByPartAll)
+      p <- p + jaspGraphs::geom_point(data = dataset, ggplot2::aes_string(x = parts, y = "Measurement"), col = "gray")
 
-  p <- p + jaspGraphs::geom_point(data = means, ggplot2::aes_string(x = parts, y = "Measurement")) +
-    ggplot2::scale_y_continuous(limits = c(min(dataset["Measurement"]) * 0.9, max(dataset["Measurement"]) * 1.1))
+    p <- p + jaspGraphs::geom_point(data = means, ggplot2::aes_string(x = parts, y = "Measurement")) +
+      ggplot2::scale_y_continuous(limits = c(min(dataset["Measurement"]) * 0.9, max(dataset["Measurement"]) * 1.1))
 
-  p <- jaspGraphs::themeJasp(p)
+    p <- jaspGraphs::themeJasp(p)
 
-  plot$plotObject <- p
+    plot$plotObject <- p
+
+  }
 
   return(plot)
 }
 
 
-.gaugeByOperatorGraph <- function(dataset, measurements, parts, operators, options){
-
-
-  dataset <- tidyr::gather(dataset, Repetition, Measurement, measurements[1]:measurements[length(measurements)], factor_key=TRUE)
+.gaugeByOperatorGraph <- function(dataset, measurements, parts, operators, options, ready){
 
   plot <- createJaspPlot(title = gettext("Measurements by Operator"))
-
   plot$dependOn(c("gaugeByOperator", "gaugeRRmethod"))
 
-  p <- ggplot2::ggplot() +
-    ggplot2::geom_boxplot(data = dataset, ggplot2::aes_string(x = operators, y = "Measurement"))
+  if (ready){
+    dataset <- tidyr::gather(dataset, Repetition, Measurement, measurements[1]:measurements[length(measurements)], factor_key=TRUE)
 
-  p <- jaspGraphs::themeJasp(p)
+    p <- ggplot2::ggplot() +
+      ggplot2::geom_boxplot(data = dataset, ggplot2::aes_string(x = operators, y = "Measurement"))
 
-  plot$plotObject <- p
+    p <- jaspGraphs::themeJasp(p)
 
+    plot$plotObject <- p
+  }
   return(plot)
 }
 
-.gaugeByInteractionGraph <- function(dataset, measurements, parts, operators, options){
-
-  byOperator <- split.data.frame(dataset, dataset[operators])
-
-  partNames <- levels(as.factor(dataset[[parts]]))
-
-  meansPerOperator <- data.frame(Part = factor(partNames, partNames))
-
+.gaugeByInteractionGraph <- function(dataset, measurements, parts, operators, options, ready){
 
   plot <- createJaspPlot(title = gettext("Parts by Operator Interaction"), width = 700, height = 400)
-
   plot$dependOn(c("gaugeByInteraction", "gaugeRRmethod"))
 
-  for(i in 1:length(names(byOperator))){
-    name <- names(byOperator)[i]
-    if (length(rowMeans(byOperator[[name]][c(measurements)])) != length(partNames)){
-      plot$setError(gettext("Operators measured different number of parts."))
-      return(plot)
+  if (ready){
+    byOperator <- split.data.frame(dataset, dataset[operators])
+    partNames <- levels(as.factor(dataset[[parts]]))
+    meansPerOperator <- data.frame(Part = factor(partNames, partNames))
+
+    for(i in 1:length(names(byOperator))){
+      name <- names(byOperator)[i]
+      if (length(rowMeans(byOperator[[name]][c(measurements)])) != length(partNames)){
+        plot$setError(gettext("Operators measured different number of parts."))
+        return(plot)
+      }
+      meansPerOperator <- cbind(meansPerOperator, rowMeans(byOperator[[name]][c(measurements)]))
     }
-    meansPerOperator <- cbind(meansPerOperator, rowMeans(byOperator[[name]][c(measurements)]))
+
+    colnames(meansPerOperator)[-1] <- names(byOperator)
+    tidydata <- tidyr::gather(meansPerOperator, key = "Operator", value = "Measurements", -Part )
+
+    p <- ggplot2::ggplot(tidydata, ggplot2::aes(x = Part, y = Measurements, col = Operator, group = Operator)) +
+      jaspGraphs::geom_line() + jaspGraphs::geom_point()
+    p <- jaspGraphs::themeJasp(p) + ggplot2::theme(legend.position = 'right')
+    ggplot2::ylab("Measurement") +
+      ggplot2::scale_y_continuous(limits = c(min(meansPerOperator[names(byOperator)]) * 0.9, max(meansPerOperator[names(byOperator)]) * 1.1))
+    plot$plotObject <- p
   }
-  colnames(meansPerOperator)[-1] <- names(byOperator)
-
-  tidydata <- tidyr::gather(meansPerOperator, key = "Operator", value = "Measurements", -Part )
-
-  p <- ggplot2::ggplot(tidydata, ggplot2::aes(x = Part, y = Measurements, col = Operator, group = Operator)) +
-    jaspGraphs::geom_line() + jaspGraphs::geom_point()
-
-
-  p <- jaspGraphs::themeJasp(p) + ggplot2::theme(legend.position = 'right')
-  ggplot2::ylab("Measurement") +
-    ggplot2::scale_y_continuous(limits = c(min(meansPerOperator[names(byOperator)]) * 0.9, max(meansPerOperator[names(byOperator)]) * 1.1))
-
-
-
-  plot$plotObject <- p
-
   return(plot)
 }
 
@@ -677,39 +668,40 @@ msaGaugeRR <- function(jaspResults, dataset, options, ...){
   }
 }
 
-.gaugeScatterPlotOperators <- function(dataset, measurements, parts, operators, options){
+.gaugeScatterPlotOperators <- function(dataset, measurements, parts, operators, options, ready){
 
   plot <- createJaspPlot(title = gettext("Scatterplot of Operator A vs Operator B"))
   plot$dependOn(c("gaugeScatterPlotOperators", "gaugeScatterPlotFitLine", "gaugeScatterPlotOriginLine", "gaugeRRmethod"))
 
-  if(length(unique(dataset[[operators]])) > 2){
-    plot$setError(gettext("Plotting not possible: More than 2 Operators"))
-  }else{
+  if (ready){
+    if(length(unique(dataset[[operators]])) > 2){
+      plot$setError(gettext("Plotting not possible: More than 2 Operators"))
+    }else{
 
-    operatorSplit <- split.data.frame(dataset, dataset[operators])
+      operatorSplit <- split.data.frame(dataset, dataset[operators])
 
-    if (length(rowMeans(operatorSplit[[1]][measurements]) != length(rowMeans(operatorSplit[[2]][measurements])))){
-      plot$setError(gettext("Operators measured different number of parts."))
-      return(plot)
+      if (length(rowMeans(operatorSplit[[1]][measurements]) != length(rowMeans(operatorSplit[[2]][measurements])))){
+        plot$setError(gettext("Operators measured different number of parts."))
+        return(plot)
+      }
+
+      data <- data.frame(OperatorA = rowMeans(operatorSplit[[1]][measurements]), OperatorB = rowMeans(operatorSplit[[2]][measurements]))
+
+      p <- ggplot2::ggplot(data = data, ggplot2::aes_string(x = "OperatorA", y = "OperatorB")) +
+        jaspGraphs::geom_point() + ggplot2::scale_x_continuous(limits = c(min(dataset[measurements])*0.9,max(dataset[measurements])*1.1)) +
+        ggplot2::scale_y_continuous(limits = c(min(dataset[measurements])*0.9,max(dataset[measurements])*1.1))
+
+      if (options[["gaugeScatterPlotFitLine"]])
+        p <- p + ggplot2::geom_smooth(method = "lm", se = FALSE)
+
+      if (options[["gaugeScatterPlotOriginLine"]])
+        p <- p + ggplot2::geom_abline(col = "gray", linetype = "dashed")
+
+      p <- jaspGraphs::themeJasp(p)
+
+      plot$plotObject <- p
     }
-
-    data <- data.frame(OperatorA = rowMeans(operatorSplit[[1]][measurements]), OperatorB = rowMeans(operatorSplit[[2]][measurements]))
-
-    p <- ggplot2::ggplot(data = data, ggplot2::aes_string(x = "OperatorA", y = "OperatorB")) +
-      jaspGraphs::geom_point() + ggplot2::scale_x_continuous(limits = c(min(dataset[measurements])*0.9,max(dataset[measurements])*1.1)) +
-      ggplot2::scale_y_continuous(limits = c(min(dataset[measurements])*0.9,max(dataset[measurements])*1.1))
-
-    if (options[["gaugeScatterPlotFitLine"]])
-      p <- p + ggplot2::geom_smooth(method = "lm", se = FALSE)
-
-    if (options[["gaugeScatterPlotOriginLine"]])
-      p <- p + ggplot2::geom_abline(col = "gray", linetype = "dashed")
-
-    p <- jaspGraphs::themeJasp(p)
-
-    plot$plotObject <- p
   }
-
   return(plot)
 }
 

--- a/R/msaType1Gauge.R
+++ b/R/msaType1Gauge.R
@@ -189,7 +189,8 @@ msaType1Gauge <- function(jaspResults, dataset, options, ...){
 
     plot <- createJaspPlot(title = gettext("Bias Histogram"), width = 400, height = 400)
 
-    p <- jaspDescriptives:::.plotMarginal(column = dataForPart, variableName = "Measurement")
+    p <- jaspDescriptives:::.plotMarginal(column = dataForPart, variableName = "Measurement",
+                                          binWidthType = options$biasBinWidthType, numberOfBins = options$biasNumberOfBins)
 
     plot$dependOn(c("biasHistogram"))
 

--- a/inst/qml/msaGaugeRR.qml
+++ b/inst/qml/msaGaugeRR.qml
@@ -60,24 +60,20 @@ Form
 		}
 
 	}
+	DropDown 
+	{
+		name: "gaugeRRmethod"
+		label: qsTr("Gauge r&R Method")
+		indexDefaultValue: 0
+		values:
+		[	
+			{label: qsTr("ANOVA method"),					value: "anovaMethod"},
+			{label: qsTr("Range method"),				value: "rangeMethod"},
+		]
+		id: gaugeRRmethod
+	}
 	
-
-		
-		
-		DropDown {
-                name: "gaugeRRmethod"
-                label: qsTr("Gauge r&R Method")
-                indexDefaultValue: 0
-                values:
-                [	
-					{label: qsTr("ANOVA method"),					value: "anovaMethod"},
-					{label: qsTr("Range method"),				value: "rangeMethod"},
-				]
-				
-				id: gaugeRRmethod
-				}
-	
-		Section
+	Section
 	{
 		title: qsTr("ANOVA Method Options")
 		visible: gaugeRRmethod.currentValue == "anovaMethod"
@@ -86,71 +82,81 @@ Form
 		{
 			title: qsTr("Analysis Options")
 			
-									DropDown {
-                name: "standardDeviationReference"
-                label: qsTr("Std. Deviation reference")
-                indexDefaultValue: 0
-                values:
-                [	
+			DropDown
+			{
+				name: "standardDeviationReference"
+				label: qsTr("Std. Deviation reference")
+				indexDefaultValue: 0
+				values:
+				[
 					{label: qsTr("Study Std. Deviation"),					value: "studyStandardDeviation"},
-					{label: qsTr("Historical process Std. Deviation"),				value: "historicalStandardDeviation"},
+					{label: qsTr("Historical process Std. Deviation"),				value: "historicalStandardDeviation"}
 				]
-				
 				id: variationReference
-				}
-				DoubleField
-				{
-					name:			"historicalStandardDeviationValue"
-					label:			qsTr("Std. Deviation value:")
-					defaultValue:	0
-					enabled:		variationReference.currentValue == "historicalStandardDeviation"
-				}
+			}
 			
+			DoubleField
+			{
+				name:			"historicalStandardDeviationValue"
+				label:			qsTr("Hist. Std. Deviation value:")
+				defaultValue:	0
+				enabled:		variationReference.currentValue == "historicalStandardDeviation"
+			}
 			
-
-				DoubleField
-				{
-					name:			"tolerance"
-					label:			qsTr("Tolerance:")
-					defaultValue:	10
-					enabled:		TRUE
-				}
+			DoubleField
+			{
+				name:			"tolerance"
+				label:			qsTr("Tolerance:")
+				defaultValue:	10
+			}
 			
 			CheckBox
 			{
-				name: "gaugeANOVA";		label: qsTr("r&R table ANOVA method"); checked: true
+				name: "gaugeANOVA"
+				label: qsTr("r&R table ANOVA method")
+				checked: true
 			
-						DoubleField { name: "alphaForANOVA";		label: qsTr("Alpha interaction removal:");	fieldWidth: 60; defaultValue: 0.05; max: 1; decimals: 3 }
-					
-				
-				DropDown{
-						name: "studyVarMultiplierType"
-						label: qsTr("Study Var. multiplier type")
-						indexDefaultValue: 0
-						values:
-							[
-							{label: qsTr("Std. Deviation"),		value: "svmSD"},
-							{label: qsTr("Percent"),				value: "svmPercent"},
-							]
-						id: studyVarMultiplierType
-						}
+				DoubleField 
+				{
+					name: "alphaForANOVA"
+					label: qsTr("Alpha interaction removal:")
+					fieldWidth: 60
+					defaultValue: 0.05 
+					max: 1
+					decimals: 3
+				}
+			
+				DropDown
+				{
+					name: "studyVarMultiplierType"
+					label: qsTr("Study Var. multiplier type")
+					indexDefaultValue: 0
+					values:
+					[
+						{label: qsTr("Std. Deviation"),		value: "svmSD"},
+						{label: qsTr("Percent"),				value: "svmPercent"}
+					]
+					id: studyVarMultiplierType
+				}
 										
-				DoubleField { 
-						name: "studyVarMultiplier"
-						label: qsTr("Study Var. multiplier value:")
-						fieldWidth: 60 
-						defaultValue: 6
-						min:			0.001;
-						max:			99.999;						
-						decimals: 3
-						}
-					
-				CheckBox{
-						name: "gaugeVarCompGraph";		label: qsTr("Graph variation components"); checked: true
-						}
-				
+				DoubleField
+				{ 
+					name: "studyVarMultiplier"
+					label: qsTr("Study Var. multiplier value:")
+					fieldWidth: 60 
+					defaultValue: 6
+					min:			0.001
+					max:			99.999						
+					decimals: 3
+				}
+			
+				CheckBox
+				{
+					name: "gaugeVarCompGraph"
+					label: qsTr("Graph variation components")
+					checked: true
+				}
 			}
-		
 		}
 		
 		Group
@@ -159,47 +165,56 @@ Form
 
 			CheckBox
 			{
-				name: "gaugeRchart";		label: qsTr("R charts by operator")
+				name: "gaugeRchart"
+				label: qsTr("R charts by operator")
 			}
-
+			
 			CheckBox
 			{
-				name: "gaugeXbarChart";		label: qsTr("X-bar charts by operator")
+				name: "gaugeXbarChart"
+				label: qsTr("X-bar charts by operator")
 			}
 		
 			CheckBox
 			{
-				name: "gaugeScatterPlotOperators";		label: qsTr("Scatter plots operators")
+				name: "gaugeScatterPlotOperators"
+				label: qsTr("Scatter plots operators")
 				
 				CheckBox
 				{
-					name: "gaugeScatterPlotFitLine";		label: qsTr("Fit line")
+					name: "gaugeScatterPlotFitLine"
+					label: qsTr("Fit line")
 				}
 
 				CheckBox
 				{
-					name: "gaugeScatterPlotOriginLine";		label: qsTr("Show origin line")
+					name: "gaugeScatterPlotOriginLine"
+					label: qsTr("Show origin line")
 				}
 			}
 
 			CheckBox
 			{
-			name: "gaugeByPart";		label: qsTr("Measurement by part plot")
+				name: "gaugeByPart"
+				label: qsTr("Measurement by part plot")
 			
 				CheckBox
 				{
-					name: "gaugeByPartAll";		label: qsTr("Display all measurements")
+					name: "gaugeByPartAll"
+					label: qsTr("Display all measurements")
 				}
 			}	
 
 			CheckBox
 			{
-			name: "gaugeByOperator";		label: qsTr("Measurement by operators plot")
+			name: "gaugeByOperator"
+			label: qsTr("Measurement by operators plot")
 			}
 		
 			CheckBox
 			{
-			name: "gaugeByInteraction";		label: qsTr("Measurement interaction plot")
+			name: "gaugeByInteraction"
+			label: qsTr("Measurement interaction plot")
 			}
 		}
 	}
@@ -209,52 +224,63 @@ Form
 		title: qsTr("Range Method Options")
 		visible: gaugeRRmethod.currentValue == "rangeMethod"
 		
-			Group
-			{
-				title: qsTr("Analysis Options")
-				
-								DoubleField
-				{
-					name:			"rangePSD"
-					label:			qsTr("Process Std. Deviation:")
-					defaultValue:	1
-					enabled:		TRUE
-				}
-				
-				CheckBox
-				{
-					name: "rangeRr";		label: qsTr("r&R table"); checked: true
-				}
-			}
-		
-			Group
-			{
-				title: qsTr("Plots")
-				
-				CheckBox
-				{
-					name: "rangeScatterPlotOperatorParts";		label: qsTr("Scatter plot operators vs. parts")
-				}
+		Group
+		{
+			title: qsTr("Analysis Options")
 			
-				CheckBox
-				{
-					name: "rangeScatterPlotOperators";		label: qsTr("Scatter plot operators"); checked: true
-				
-					CheckBox
-					{
-						name: "rangeScatterPlotFitLine";		label: qsTr("Fit line"); checked: true
-					}
-				
-					CheckBox
-					{
-						name: "rangeScatterPlotOriginLine";		label: qsTr("Show origin line"); checked: true
-					}
-		
-				}
-				CheckBox
-				{
-					name: "rangeRchart";		label: qsTr("R chart")
-				}
+			DoubleField
+			{
+				name:			"rangePSD"
+				label:			qsTr("Process Std. Deviation:")
+				defaultValue:	1
+				enabled:		TRUE
 			}
+			
+			CheckBox
+			{
+				name: "rangeRr"
+				label: qsTr("r&R table")
+				checked: true
+			}
+		}
+		
+		Group
+		{
+			title: qsTr("Plots")
+				
+			CheckBox
+			{
+				name: "rangeScatterPlotOperatorParts"
+				label: qsTr("Scatter plot operators vs. parts")
+			}
+			
+			CheckBox
+			{
+				name: "rangeScatterPlotOperators"
+				label: qsTr("Scatter plot operators")
+				checked: true
+				
+				CheckBox
+				{
+					name: "rangeScatterPlotFitLine"
+					label: qsTr("Fit line")
+					checked: true
+				}
+				
+				CheckBox
+				{
+					name: "rangeScatterPlotOriginLine"
+					label: qsTr("Show origin line")
+					checked: true
+				}
+		
+			}
+			
+			CheckBox
+			{
+				name: "rangeRchart"
+				label: qsTr("R chart")
+			}
+		}
 	}
 }

--- a/inst/qml/msaGaugeRR.qml
+++ b/inst/qml/msaGaugeRR.qml
@@ -61,17 +61,26 @@ Form
 
 	}
 	
-			RadioButtonGroup
-		{
-			name: "gaugeRRmethod"
-			RadioButton { name: "anovaMethod";	label: qsTr("ANOVA Method"); checked: true}
-			RadioButton { name: "rangeMethod";  label: qsTr("Range Method")	}
-		}
-	
+
+		
+		
+		DropDown {
+                name: "gaugeRRmethod"
+                label: qsTr("Gauge r&R Method")
+                indexDefaultValue: 0
+                values:
+                [	
+					{label: qsTr("ANOVA method"),					value: "anovaMethod"},
+					{label: qsTr("Range method"),				value: "rangeMethod"},
+				]
+				
+				id: gaugeRRmethod
+				}
 	
 		Section
 	{
 		title: qsTr("ANOVA Method Options")
+		visible: gaugeRRmethod.currentValue == "anovaMethod"
 		
 		Group
 		{
@@ -198,6 +207,7 @@ Form
 	Section
 	{
 		title: qsTr("Range Method Options")
+		visible: gaugeRRmethod.currentValue == "rangeMethod"
 		
 			Group
 			{

--- a/inst/qml/msaType1Gauge.qml
+++ b/inst/qml/msaType1Gauge.qml
@@ -104,6 +104,30 @@ Form
 		CheckBox
 		{
 			name: "biasHistogram";		label: qsTr("Histogram")
+			
+							DropDown {
+					name: "biasBinWidthType"
+					label: qsTr("Bin width type")
+					indexDefaultValue: 0
+					values:
+						[
+						{label: qsTr("Sturges"),				value: "sturges"},
+						{label: qsTr("Scott"),					value: "scott"},
+						{label: qsTr("Doane"),					value: "doane"},
+						{label: qsTr("Freedman-Diaconis"),		value: "fd"	},
+						{label: qsTr("Manual"),					value: "manual"	}
+					]
+					id: binWidthType
+				}
+				DoubleField
+				{
+					name:			"biasNumberOfBins"
+					label:			qsTr("Number of bins")
+					defaultValue:	30
+					min:			3;
+					max:			10000;
+					enabled:		binWidthType.currentValue === "manual"
+				}
 		}
 
 


### PR DESCRIPTION
-Added bin width options to histogram in type 1 gauge analysis
-Fixed bug, where "Gauge RR: ANOVA method: Scatterplot operator & measurement by part graph & measurement by operator & measurement interaction graph crashes when no variables" (added ready checks)
-Changed gauge r&R method selection to dropdown
-Implemented functionality to hide gauge r&R analysis options for alternative analysis method when not selected
-Fixed indentation in gaugeRR.qml